### PR TITLE
feat: Add `casing` and `is-letter` blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ jsrepo add types/result
 | [types/result](https://ieedan.github.io/std/classes/types_result.Result.html)                           | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/array-sum](https://ieedan.github.io/std/functions/utils_array-sum.arraySum.html)                 | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/array-to-map](https://ieedan.github.io/std/functions/utils_array-to-map.arrayToMap.html)         | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
-| [utils/casing](https://ieedan.github.io/std/functions/utils_casing.html)                                | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
+| [utils/casing](https://ieedan.github.io/std/modules/utils_casing.html)                                  | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/dispatcher](https://ieedan.github.io/std/classes/utils_dispatcher.Dispatcher.html)               | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/ipv4-address](https://ieedan.github.io/std/modules/utils_ipv4-address.html)                      | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
-| [utils/is-letter](https://ieedan.github.io/std/modules/utils_is-letter.isLetter.html)                   | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
+| [utils/is-letter](https://ieedan.github.io/std/functions/utils_is-letter.isLetter.html)                 | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/is-number](https://ieedan.github.io/std/functions/utils_is-number.isNumber.html)                 | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/lines](https://ieedan.github.io/std/modules/utils_lines.html)                                    | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/map-to-array](https://ieedan.github.io/std/functions/utils_map-to-array.mapToArray.html)         | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ jsrepo add types/result
 | [types/result](https://ieedan.github.io/std/classes/types_result.Result.html)                           | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/array-sum](https://ieedan.github.io/std/functions/utils_array-sum.arraySum.html)                 | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/array-to-map](https://ieedan.github.io/std/functions/utils_array-to-map.arrayToMap.html)         | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
+| [utils/casing](https://ieedan.github.io/std/functions/utils_casing.html)                                | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/dispatcher](https://ieedan.github.io/std/classes/utils_dispatcher.Dispatcher.html)               | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/ipv4-address](https://ieedan.github.io/std/modules/utils_ipv4-address.html)                      | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
+| [utils/is-letter](https://ieedan.github.io/std/modules/utils_is-letter.isLetter.html)                   | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/is-number](https://ieedan.github.io/std/functions/utils_is-number.isNumber.html)                 | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/lines](https://ieedan.github.io/std/modules/utils_lines.html)                                    | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |
 | [utils/map-to-array](https://ieedan.github.io/std/functions/utils_map-to-array.mapToArray.html)         | ![Tests](https://raw.githubusercontent.com/ieedan/std/refs/heads/main/badges/coverage-total.svg) |

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,7 @@
 		"attributePosition": "auto"
 	},
 	"files": {
-		"ignore": ["dist", "node_modules", "docs", "blocks-manifest.json"]
+		"ignore": ["dist", "node_modules", "docs", "blocks-manifest.json", "coverage"]
 	},
 	"organizeImports": { "enabled": true },
 	"linter": {
@@ -52,6 +52,7 @@
 			},
 			"style": { "noNamespace": "error", "useAsConstAssertion": "error" },
 			"suspicious": {
+				"noConsoleLog": "error",
 				"noAsyncPromiseExecutor": "error",
 				"noCatchAssign": "error",
 				"noClassAssign": "error",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
-		"@types/node": "^22.13.0",
+		"@types/node": "^22.13.1",
 		"@vitest/coverage-v8": "^3.0.5",
-		"jsrepo": "^1.30.1",
+		"jsrepo": "^1.31.0",
 		"typedoc": "^0.27.6",
 		"typescript": "^5.7.3",
 		"vitest": "^3.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,14 +19,14 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@types/node':
-        specifier: ^22.13.0
-        version: 22.13.0
+        specifier: ^22.13.1
+        version: 22.13.1
       '@vitest/coverage-v8':
         specifier: ^3.0.5
-        version: 3.0.5(vitest@3.0.5(@types/node@22.13.0)(yaml@2.7.0))
+        version: 3.0.5(vitest@3.0.5(@types/node@22.13.1)(yaml@2.7.0))
       jsrepo:
-        specifier: ^1.30.1
-        version: 1.30.1(typescript@5.7.3)
+        specifier: ^1.31.0
+        version: 1.31.0(typescript@5.7.3)
       typedoc:
         specifier: ^0.27.6
         version: 0.27.6(typescript@5.7.3)
@@ -35,7 +35,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: ^3.0.5
-        version: 3.0.5(@types/node@22.13.0)(yaml@2.7.0)
+        version: 3.0.5(@types/node@22.13.1)(yaml@2.7.0)
 
 packages:
 
@@ -577,8 +577,8 @@ packages:
   '@types/node@18.19.74':
     resolution: {integrity: sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==}
 
-  '@types/node@22.13.0':
-    resolution: {integrity: sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==}
+  '@types/node@22.13.1':
+    resolution: {integrity: sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1033,8 +1033,8 @@ packages:
   json-schema-typed@8.0.1:
     resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
 
-  jsrepo@1.30.1:
-    resolution: {integrity: sha512-IpxofyrRmocf2FZNWHS/STdLq3zlECq1MvYEib2yx/Szfjj7hdUG9cZqUApaQP6pZA/t6u0b0QNhAxBRcoEpVA==}
+  jsrepo@1.31.0:
+    resolution: {integrity: sha512-RoeyAkcxx2hBEnYOExrmyiF+bDF9r+Wg2DrLEgm1T4e/6WmNRDk9ZnlzD4Y16TSj5kjWj+lcbNl3pvbV8FQl0w==}
     hasBin: true
 
   linkify-it@5.0.0:
@@ -1231,6 +1231,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1290,8 +1295,8 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  svelte@5.19.6:
-    resolution: {integrity: sha512-6ydekB3qyqUal+UhfMjmVOjRGtxysR8vuiMhi2nwuBtPJWnctVlsGspjVFB05qmR+TXI1emuqtZt81c0XiFleA==}
+  svelte@5.19.8:
+    resolution: {integrity: sha512-56Vd/nwJrljV0w7RCV1A8sB4/yjSbWW5qrGDTAzp7q42OxwqEWT+6obWzDt41tHjIW+C9Fs2ygtejjJrXR+ZPA==}
     engines: {node: '>=18'}
 
   test-exclude@7.0.1:
@@ -1974,20 +1979,20 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 22.13.0
+      '@types/node': 22.13.1
       form-data: 4.0.1
 
   '@types/node@18.19.74':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@22.13.0':
+  '@types/node@22.13.1':
     dependencies:
       undici-types: 6.20.0
 
   '@types/unist@3.0.3': {}
 
-  '@vitest/coverage-v8@3.0.5(vitest@3.0.5(@types/node@22.13.0)(yaml@2.7.0))':
+  '@vitest/coverage-v8@3.0.5(vitest@3.0.5(@types/node@22.13.1)(yaml@2.7.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2001,7 +2006,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.0)(yaml@2.7.0)
+      vitest: 3.0.5(@types/node@22.13.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2012,13 +2017,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.13.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.13.1)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.13.0)(yaml@2.7.0)
+      vite: 6.0.11(@types/node@22.13.1)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -2221,7 +2226,7 @@ snapshots:
       dot-prop: 9.0.0
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
-      semver: 7.7.0
+      semver: 7.7.1
       uint8array-extras: 1.4.0
 
   cross-spawn@7.0.6:
@@ -2472,7 +2477,7 @@ snapshots:
 
   json-schema-typed@8.0.1: {}
 
-  jsrepo@1.30.1(typescript@5.7.3):
+  jsrepo@1.31.0(typescript@5.7.3):
     dependencies:
       '@anthropic-ai/sdk': 0.36.3
       '@biomejs/js-api': 0.7.1(@biomejs/wasm-nodejs@1.9.4)
@@ -2497,8 +2502,8 @@ snapshots:
       parse5: 7.2.1
       pathe: 2.0.2
       prettier: 3.4.2
-      semver: 7.7.0
-      svelte: 5.19.6
+      semver: 7.7.1
+      svelte: 5.19.8
       ts-morph: 25.0.0
       valibot: 1.0.0-beta.14(typescript@5.7.3)
       validate-npm-package-name: 6.0.0
@@ -2701,6 +2706,8 @@ snapshots:
 
   semver@7.7.0: {}
 
+  semver@7.7.1: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -2753,7 +2760,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte@5.19.6:
+  svelte@5.19.8:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -2837,13 +2844,13 @@ snapshots:
 
   validate-npm-package-name@6.0.0: {}
 
-  vite-node@3.0.5(@types/node@22.13.0)(yaml@2.7.0):
+  vite-node@3.0.5(@types/node@22.13.1)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.0.11(@types/node@22.13.0)(yaml@2.7.0)
+      vite: 6.0.11(@types/node@22.13.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2858,20 +2865,20 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.0.11(@types/node@22.13.0)(yaml@2.7.0):
+  vite@6.0.11(@types/node@22.13.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.34.1
     optionalDependencies:
-      '@types/node': 22.13.0
+      '@types/node': 22.13.1
       fsevents: 2.3.3
       yaml: 2.7.0
 
-  vitest@3.0.5(@types/node@22.13.0)(yaml@2.7.0):
+  vitest@3.0.5(@types/node@22.13.1)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.13.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.13.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -2887,11 +2894,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@22.13.0)(yaml@2.7.0)
-      vite-node: 3.0.5(@types/node@22.13.0)(yaml@2.7.0)
+      vite: 6.0.11(@types/node@22.13.1)(yaml@2.7.0)
+      vite-node: 3.0.5(@types/node@22.13.1)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.0
+      '@types/node': 22.13.1
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/utils/casing.test.ts
+++ b/src/utils/casing.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import * as casing from './casing';
+
+describe('pascalToSnake', () => {
+	it('correctly converts to snake_case', () => {
+		expect(casing.pascalToSnake('HelloWorld')).toBe('hello_world');
+		expect(casing.pascalToSnake('Hello')).toBe('hello');
+		expect(casing.pascalToSnake('_Hello')).toBe('_hello');
+		expect(casing.pascalToSnake('HelloH')).toBe('hello_h');
+	});
+
+	it('does not separate back to back capitals', () => {
+		expect(casing.pascalToSnake('APIKey')).toBe('api_key');
+	});
+});
+
+describe('camelToSnake', () => {
+	it('correctly converts to snake_case', () => {
+		expect(casing.camelToSnake('helloWorld')).toBe('hello_world');
+		expect(casing.camelToSnake('hello')).toBe('hello');
+		expect(casing.camelToSnake('_hello')).toBe('_hello');
+		expect(casing.camelToSnake('helloH')).toBe('hello_h');
+	});
+
+	it('does not separate back to back capitals', () => {
+		expect(casing.camelToSnake('APIKey')).toBe('api_key');
+	});
+});
+
+describe('pascalToKebab', () => {
+	it('correctly converts to kebab-case', () => {
+		expect(casing.pascalToKebab('HelloWorld')).toBe('hello-world');
+		expect(casing.pascalToKebab('Hello')).toBe('hello');
+		expect(casing.pascalToKebab('HelloH')).toBe('hello-h');
+	});
+
+	it('does not separate back to back capitals', () => {
+		expect(casing.pascalToKebab('APIKey')).toBe('api-key');
+	});
+});
+
+describe('camelToKebab', () => {
+	it('correctly converts to kebab-case', () => {
+		expect(casing.camelToKebab('helloWorld')).toBe('hello-world');
+		expect(casing.camelToKebab('hello')).toBe('hello');
+		expect(casing.camelToKebab('helloH')).toBe('hello-h');
+	});
+
+	it('does not separate back to back capitals', () => {
+		expect(casing.camelToKebab('APIKey')).toBe('api-key');
+	});
+});
+
+describe('pascalToCamel', () => {
+	it('correctly converts to camelCase', () => {
+		expect(casing.pascalToCamel('HelloWorld')).toBe('helloWorld');
+		expect(casing.pascalToCamel('Hello')).toBe('hello');
+	});
+});
+
+describe('camelToPascal', () => {
+	it('correctly converts to PascalCase', () => {
+		expect(casing.camelToPascal('helloWorld')).toBe('HelloWorld');
+		expect(casing.camelToPascal('hello')).toBe('Hello');
+	});
+});
+
+describe('snakeToCamel', () => {
+	it('correctly converts to camelCase', () => {
+		expect(casing.snakeToCamel('hello_world')).toBe('helloWorld');
+		expect(casing.snakeToCamel('HELLO_WORLD')).toBe('helloWorld');
+		expect(casing.snakeToCamel('hello')).toBe('hello');
+	});
+
+	it('leaves leading underscore', () => {
+		expect(casing.snakeToCamel('_hello_world')).toBe('_helloWorld');
+		expect(casing.snakeToCamel('___hello_world')).toBe('___helloWorld');
+	});
+
+	it('Correctly handles trailing underscore', () => {
+		expect(casing.snakeToCamel('_hello_world_')).toBe('_helloWorld_');
+	});
+});
+
+describe('snakeToPascal', () => {
+	it('correctly converts to PascalCase', () => {
+		expect(casing.snakeToPascal('hello_world')).toBe('HelloWorld');
+		expect(casing.snakeToPascal('HELLO_WORLD')).toBe('HelloWorld');
+		expect(casing.snakeToPascal('hello')).toBe('Hello');
+	});
+
+	it('leaves leading underscore', () => {
+		expect(casing.snakeToPascal('_hello_world')).toBe('_HelloWorld');
+		expect(casing.snakeToPascal('___hello_world')).toBe('___HelloWorld');
+	});
+
+	it('Correctly handles trailing underscore', () => {
+		expect(casing.snakeToPascal('_hello_world_')).toBe('_HelloWorld_');
+	});
+});
+
+describe('kebabToCamel', () => {
+	it('correctly converts to camelCase', () => {
+		expect(casing.kebabToCamel('hello-world')).toBe('helloWorld');
+		expect(casing.kebabToCamel('hello')).toBe('hello');
+	});
+
+	it('Removes trailing dash', () => {
+		expect(casing.kebabToCamel('hello-world-')).toBe('helloWorld');
+	});
+});
+
+describe('kebabToPascal', () => {
+	it('correctly converts to PascalCase', () => {
+		expect(casing.kebabToPascal('hello-world')).toBe('HelloWorld');
+		expect(casing.kebabToPascal('hello')).toBe('Hello');
+	});
+
+	it('Removes trailing dash', () => {
+		expect(casing.kebabToPascal('hello-world-')).toBe('HelloWorld');
+	});
+});

--- a/src/utils/casing.ts
+++ b/src/utils/casing.ts
@@ -1,0 +1,324 @@
+import { isLetter } from './is-letter';
+
+/** Converts a `camelCase` string to a `snake_case` string
+ *
+ * ## Usage
+ * ```ts
+ * camelToSnake('helloWorld'); // hello_world
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const camelToSnake = (str: string) => {
+	let newStr = '';
+
+	for (let i = 0; i < str.length; i++) {
+		// is uppercase letter
+		if (isLetter(str[i]) && str[i].toUpperCase() === str[i]) {
+			let l = i;
+
+			while (l < str.length && isLetter(str[l]) && str[l].toUpperCase() === str[l]) {
+				l++;
+			}
+
+			newStr += `${str.slice(i, l - 1).toLocaleLowerCase()}_${str[l - 1].toLocaleLowerCase()}`;
+
+			i = l - 1;
+
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `PascalCase` string to a `snake_case` string
+ *
+ * ## Usage
+ * ```ts
+ * camelToSnake('HelloWorld'); // hello_world
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const pascalToSnake = (str: string) => {
+	let newStr = '';
+
+	let firstLetter: number | undefined;
+
+	for (let i = 0; i < str.length; i++) {
+		if (firstLetter === undefined && isLetter(str[i])) {
+			firstLetter = i;
+		}
+
+		// is uppercase letter (ignoring the first)
+		if (
+			firstLetter !== undefined &&
+			i > firstLetter &&
+			isLetter(str[i]) &&
+			str[i].toUpperCase() === str[i]
+		) {
+			let l = i;
+
+			while (l < str.length && isLetter(str[l]) && str[l].toUpperCase() === str[l]) {
+				l++;
+			}
+
+			newStr += `${str.slice(i, l - 1).toLocaleLowerCase()}_${str[l - 1].toLocaleLowerCase()}`;
+
+			i = l - 1;
+
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `camelCase` string to a `kebab-case` string
+ *
+ * ## Usage
+ * ```ts
+ * camelToSnake('helloWorld'); // hello-world
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const camelToKebab = (str: string) => {
+	let newStr = '';
+
+	for (let i = 0; i < str.length; i++) {
+		// is uppercase letter
+		if (i > 0 && isLetter(str[i]) && str[i].toUpperCase() === str[i]) {
+			let l = i;
+
+			while (l < str.length && isLetter(str[l]) && str[l].toUpperCase() === str[l]) {
+				l++;
+			}
+
+			newStr += `${str.slice(i, l - 1).toLocaleLowerCase()}-${str[l - 1].toLocaleLowerCase()}`;
+
+			i = l - 1;
+
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `PascalCase` string to a `kebab-case` string
+ *
+ * ## Usage
+ * ```ts
+ * camelToSnake('HelloWorld'); // hello-world
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const pascalToKebab = (str: string) => {
+	let newStr = '';
+
+	for (let i = 0; i < str.length; i++) {
+		// is uppercase letter (ignoring the first)
+		if (i > 0 && isLetter(str[i]) && str[i].toUpperCase() === str[i]) {
+			let l = i;
+
+			while (l < str.length && isLetter(str[l]) && str[l].toUpperCase() === str[l]) {
+				l++;
+			}
+
+			newStr += `${str.slice(i, l - 1).toLocaleLowerCase()}-${str[l - 1].toLocaleLowerCase()}`;
+
+			i = l - 1;
+
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `camelCase` string to a `PascalCase` string (makes first letter lowercase)
+ *
+ * ## Usage
+ * ```ts
+ * camelToPascal('helloWorld'); // HelloWorld
+ * ```
+ * @param str
+ * @returns
+ */
+export const camelToPascal = (str: string) => {
+	return `${str[0].toLocaleUpperCase()}${str.slice(1)}`;
+};
+
+/** Converts a `PascalCase` string to a `camelCase` string (makes first letter uppercase)
+ *
+ * ## Usage
+ * ```ts
+ * camelToPascal('HelloWorld'); // helloWorld
+ * ```
+ * @param str
+ * @returns
+ */
+export const pascalToCamel = (str: string) => {
+	return `${str[0].toLocaleLowerCase()}${str.slice(1)}`;
+};
+
+/** Converts a `snake_case` string to a `PascalCase` string
+ *
+ * ## Usage
+ * ```ts
+ * snakeToPascal('hello_world'); // HelloWorld
+ * snakeToPascal('HELLO_WORLD'); // HelloWorld
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const snakeToPascal = (str: string) => {
+	let newStr = '';
+
+	let firstLetter = true;
+
+	for (let i = 0; i < str.length; i++) {
+		// capitalize first letter
+		if (firstLetter && isLetter(str[i])) {
+			firstLetter = false;
+			newStr += str[i].toUpperCase();
+			continue;
+		}
+
+		// capitalize first after a _ (ignoring the first)
+		if (!firstLetter && str[i] === '_') {
+			i++;
+			if (i <= str.length - 1) {
+				newStr += str[i].toUpperCase();
+			} else {
+				newStr += '_';
+			}
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `snake_case` string to a `camelCase` string
+ *
+ * ## Usage
+ * ```ts
+ * snakeToCamel('hello_world'); // helloWorld
+ * snakeToCamel('HELLO_WORLD'); // helloWorld
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const snakeToCamel = (str: string) => {
+	let newStr = '';
+
+	let firstLetter = true;
+
+	for (let i = 0; i < str.length; i++) {
+		// capitalize first letter
+		if (firstLetter && isLetter(str[i])) {
+			firstLetter = false;
+			newStr += str[i].toLowerCase();
+			continue;
+		}
+
+		// capitalize first after a _ (ignoring the first)
+		if (!firstLetter && str[i] === '_') {
+			i++;
+			if (i <= str.length - 1) {
+				newStr += str[i].toUpperCase();
+			} else {
+				newStr += '_';
+			}
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `kebab-case` string to a `PascalCase` string
+ *
+ * ## Usage
+ * ```ts
+ * kebabToPascal('hello-world'); // HelloWorld
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const kebabToPascal = (str: string) => {
+	let newStr = '';
+
+	for (let i = 0; i < str.length; i++) {
+		// capitalize first
+		if (i === 0) {
+			newStr += str[i].toUpperCase();
+			continue;
+		}
+
+		// capitalize first after a -
+		if (str[i] === '-') {
+			i++;
+			if (i <= str.length - 1) {
+				newStr += str[i].toUpperCase();
+			}
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};
+
+/** Converts a `kebab-case` string to a `camelCase` string
+ *
+ * ## Usage
+ * ```ts
+ * kebabToCamel('hello-world'); // helloWorld
+ * ```
+ *
+ * @param str
+ * @returns
+ */
+export const kebabToCamel = (str: string) => {
+	let newStr = '';
+
+	for (let i = 0; i < str.length; i++) {
+		// capitalize first after a -
+		if (str[i] === '-') {
+			i++;
+			if (i <= str.length - 1) {
+				newStr += str[i].toUpperCase();
+			}
+			continue;
+		}
+
+		newStr += str[i].toLocaleLowerCase();
+	}
+
+	return newStr;
+};

--- a/src/utils/is-letter.test.ts
+++ b/src/utils/is-letter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isLetter } from './is-letter';
+
+const validLetters = [
+	'a',
+	'b',
+	'c',
+	'd',
+	'e',
+	'f',
+	'g',
+	'h',
+	'i',
+	'j',
+	'k',
+	'l',
+	'm',
+	'n',
+	'o',
+	'p',
+	'q',
+	'r',
+	's',
+	't',
+	'u',
+	'v',
+	'w',
+	'x',
+	'y',
+	'z',
+];
+
+describe('isLetter', () => {
+	it('correctly identifies letters', () => {
+		for (const letter of validLetters) {
+			expect(isLetter(letter)).toBe(true);
+			expect(isLetter(letter.toUpperCase())).toBe(true);
+		}
+	});
+
+	it('correctly identifies non-letters', () => {
+		expect(isLetter('1')).toBe(false);
+		expect(isLetter('|')).toBe(false);
+		expect(isLetter(']')).toBe(false);
+	});
+
+	it('throws if given more than 1 character', () => {
+		expect(() => isLetter('ab')).toThrow();
+	});
+});

--- a/src/utils/is-letter.ts
+++ b/src/utils/is-letter.ts
@@ -1,0 +1,20 @@
+export const LETTER_REGEX = new RegExp(/[a-zA-Z]/);
+
+/** Checks if the provided character is a letter in the alphabet.
+ *
+ * ## Usage
+ * ```ts
+ * isLetter('a');
+ * ```
+ * @param char
+ * @returns
+ */
+export const isLetter = (char: string) => {
+	if (char.length > 1) {
+		throw new Error(
+			`You probably only meant to pass a character to this function. Instead you gave ${char}`
+		);
+	}
+
+	return LETTER_REGEX.test(char);
+};


### PR DESCRIPTION
Casing handles case conversions from one type of case to another. I find myself needing these from time to time so it will be nice to have them all ready to go for the next time. It also has what I would consider sensible behavior for some edge cases.