### PR TITLE
chore: add cursor rules

### DIFF
--- a/.changeset/shy-fans-draw.md
+++ b/.changeset/shy-fans-draw.md
@@ -1,0 +1,6 @@
+---
+"std": patch
+---
+
+chore: Add cursor rule config file
+  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
                   commit: "chore(release): version package"
                   title: "chore(release): version package"
                   publish: pnpm ci:release
+                  version: pnpm changeset:version
               env:
                   JSREPO_TOKEN: ${{ secrets.JSREPO_TOKEN }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/jsrepo-build-config.json
+++ b/jsrepo-build-config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/jsrepo@1.30.0/schemas/registry-config.json",
+	"$schema": "https://unpkg.com/jsrepo@2.1.0/schemas/registry-config.json",
 	"name": "@ieedan/std",
 	"version": "package",
 	"meta": {
@@ -10,6 +10,14 @@
 		"repository": "https://github.com/ieedan/std",
 		"tags": ["typescript", "std", "utilities"]
 	},
+	"configFiles": [
+		{
+			"name": "Cursor Rule",
+			"expectedPath": "./.cursor/rules",
+			"path": "./rules/typescript-utility-functions.mdc",
+			"optional": true
+		}
+	],
 	"dirs": ["./src"],
 	"includeBlocks": [],
 	"includeCategories": [],

--- a/jsrepo-manifest.json
+++ b/jsrepo-manifest.json
@@ -1,12 +1,28 @@
 {
+	"name": "@ieedan/std",
+	"version": "package",
 	"meta": {
-		"authors": ["Aidan Bleser"],
+		"authors": [
+			"Aidan Bleser"
+		],
 		"bugs": "https://github.com/ieedan/std/issues",
 		"description": "Fully tested and documented TypeScript utilities brokered by jsrepo.",
 		"homepage": "https://ieedan.github.io/std/",
 		"repository": "https://github.com/ieedan/std",
-		"tags": ["typescript", "std", "utilities"]
+		"tags": [
+			"typescript",
+			"std",
+			"utilities"
+		]
 	},
+	"configFiles": [
+		{
+			"name": "Cursor Rule",
+			"path": "./rules/typescript-utility-functions.mdc",
+			"expectedPath": "./.cursor/rules",
+			"optional": true
+		}
+	],
 	"categories": [
 		{
 			"name": "ts",
@@ -18,7 +34,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["array.ts", "array.test.ts"],
+					"files": [
+						"array.ts",
+						"array.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -31,8 +50,13 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["casing.ts", "casing.test.ts"],
-					"localDependencies": ["ts/is-letter"],
+					"files": [
+						"casing.ts",
+						"casing.test.ts"
+					],
+					"localDependencies": [
+						"ts/is-letter"
+					],
 					"_imports_": {
 						"./is-letter": "{{ts/is-letter}}"
 					},
@@ -46,7 +70,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["dispatcher.ts", "dispatcher.test.ts"],
+					"files": [
+						"dispatcher.ts",
+						"dispatcher.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -59,8 +86,14 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["ipv4-address.ts", "ipv4-address.test.ts"],
-					"localDependencies": ["ts/is-number", "ts/result"],
+					"files": [
+						"ipv4-address.ts",
+						"ipv4-address.test.ts"
+					],
+					"localDependencies": [
+						"ts/is-number",
+						"ts/result"
+					],
 					"_imports_": {
 						"./is-number": "{{ts/is-number}}",
 						"./result": "{{ts/result}}"
@@ -75,7 +108,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["is-letter.ts", "is-letter.test.ts"],
+					"files": [
+						"is-letter.ts",
+						"is-letter.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -88,7 +124,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["is-number.ts", "is-number.test.ts"],
+					"files": [
+						"is-number.ts",
+						"is-number.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -101,8 +140,13 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["lines.ts", "lines.test.ts"],
-					"localDependencies": ["ts/pad"],
+					"files": [
+						"lines.ts",
+						"lines.test.ts"
+					],
+					"localDependencies": [
+						"ts/pad"
+					],
 					"_imports_": {
 						"./pad": "{{ts/pad}}"
 					},
@@ -116,7 +160,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["matcher.ts", "matcher.test.ts"],
+					"files": [
+						"matcher.ts",
+						"matcher.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -155,7 +202,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["pad.ts", "pad.test.ts"],
+					"files": [
+						"pad.ts",
+						"pad.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -168,7 +218,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["perishable-list.ts", "perishable-list.test.ts"],
+					"files": [
+						"perishable-list.ts",
+						"perishable-list.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -181,7 +234,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["promises.ts", "promises.test.ts"],
+					"files": [
+						"promises.ts",
+						"promises.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -194,7 +250,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["rand.ts", "rand.test.ts"],
+					"files": [
+						"rand.ts",
+						"rand.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -207,7 +266,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["result.ts", "result.test.ts"],
+					"files": [
+						"result.ts",
+						"result.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -220,7 +282,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["sleep.ts", "sleep.test.ts"],
+					"files": [
+						"sleep.ts",
+						"sleep.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -233,7 +298,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["stopwatch.ts", "stopwatch.test.ts"],
+					"files": [
+						"stopwatch.ts",
+						"stopwatch.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -246,7 +314,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["strings.ts", "strings.test.ts"],
+					"files": [
+						"strings.ts",
+						"strings.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -259,7 +330,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["time.ts", "time.test.ts"],
+					"files": [
+						"time.ts",
+						"time.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -272,7 +346,25 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["truncate.ts", "truncate.test.ts"],
+					"files": [
+						"truncate.ts",
+						"truncate.test.ts"
+					],
+					"localDependencies": [],
+					"_imports_": {},
+					"dependencies": [],
+					"devDependencies": []
+				},
+				{
+					"name": "types",
+					"directory": "src/ts",
+					"category": "ts",
+					"tests": false,
+					"subdirectory": false,
+					"list": true,
+					"files": [
+						"types.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -285,7 +377,10 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": ["url.ts", "url.test.ts"],
+					"files": [
+						"url.ts",
+						"url.test.ts"
+					],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],

--- a/jsrepo-manifest.json
+++ b/jsrepo-manifest.json
@@ -2,18 +2,12 @@
 	"name": "@ieedan/std",
 	"version": "package",
 	"meta": {
-		"authors": [
-			"Aidan Bleser"
-		],
+		"authors": ["Aidan Bleser"],
 		"bugs": "https://github.com/ieedan/std/issues",
 		"description": "Fully tested and documented TypeScript utilities brokered by jsrepo.",
 		"homepage": "https://ieedan.github.io/std/",
 		"repository": "https://github.com/ieedan/std",
-		"tags": [
-			"typescript",
-			"std",
-			"utilities"
-		]
+		"tags": ["typescript", "std", "utilities"]
 	},
 	"configFiles": [
 		{
@@ -34,10 +28,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"array.ts",
-						"array.test.ts"
-					],
+					"files": ["array.ts", "array.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -50,13 +41,8 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"casing.ts",
-						"casing.test.ts"
-					],
-					"localDependencies": [
-						"ts/is-letter"
-					],
+					"files": ["casing.ts", "casing.test.ts"],
+					"localDependencies": ["ts/is-letter"],
 					"_imports_": {
 						"./is-letter": "{{ts/is-letter}}"
 					},
@@ -70,10 +56,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"dispatcher.ts",
-						"dispatcher.test.ts"
-					],
+					"files": ["dispatcher.ts", "dispatcher.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -86,14 +69,8 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"ipv4-address.ts",
-						"ipv4-address.test.ts"
-					],
-					"localDependencies": [
-						"ts/is-number",
-						"ts/result"
-					],
+					"files": ["ipv4-address.ts", "ipv4-address.test.ts"],
+					"localDependencies": ["ts/is-number", "ts/result"],
 					"_imports_": {
 						"./is-number": "{{ts/is-number}}",
 						"./result": "{{ts/result}}"
@@ -108,10 +85,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"is-letter.ts",
-						"is-letter.test.ts"
-					],
+					"files": ["is-letter.ts", "is-letter.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -124,10 +98,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"is-number.ts",
-						"is-number.test.ts"
-					],
+					"files": ["is-number.ts", "is-number.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -140,13 +111,8 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"lines.ts",
-						"lines.test.ts"
-					],
-					"localDependencies": [
-						"ts/pad"
-					],
+					"files": ["lines.ts", "lines.test.ts"],
+					"localDependencies": ["ts/pad"],
 					"_imports_": {
 						"./pad": "{{ts/pad}}"
 					},
@@ -160,10 +126,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"matcher.ts",
-						"matcher.test.ts"
-					],
+					"files": ["matcher.ts", "matcher.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -202,10 +165,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"pad.ts",
-						"pad.test.ts"
-					],
+					"files": ["pad.ts", "pad.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -218,10 +178,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"perishable-list.ts",
-						"perishable-list.test.ts"
-					],
+					"files": ["perishable-list.ts", "perishable-list.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -234,10 +191,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"promises.ts",
-						"promises.test.ts"
-					],
+					"files": ["promises.ts", "promises.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -250,10 +204,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"rand.ts",
-						"rand.test.ts"
-					],
+					"files": ["rand.ts", "rand.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -266,10 +217,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"result.ts",
-						"result.test.ts"
-					],
+					"files": ["result.ts", "result.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -282,10 +230,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"sleep.ts",
-						"sleep.test.ts"
-					],
+					"files": ["sleep.ts", "sleep.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -298,10 +243,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"stopwatch.ts",
-						"stopwatch.test.ts"
-					],
+					"files": ["stopwatch.ts", "stopwatch.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -314,10 +256,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"strings.ts",
-						"strings.test.ts"
-					],
+					"files": ["strings.ts", "strings.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -330,10 +269,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"time.ts",
-						"time.test.ts"
-					],
+					"files": ["time.ts", "time.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -346,10 +282,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"truncate.ts",
-						"truncate.test.ts"
-					],
+					"files": ["truncate.ts", "truncate.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -362,9 +295,7 @@
 					"tests": false,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"types.ts"
-					],
+					"files": ["types.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],
@@ -377,10 +308,7 @@
 					"tests": true,
 					"subdirectory": false,
 					"list": true,
-					"files": [
-						"url.ts",
-						"url.test.ts"
-					],
+					"files": ["url.ts", "url.test.ts"],
 					"localDependencies": [],
 					"_imports_": {},
 					"dependencies": [],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"check:types": "tsc --noEmit",
 		"docs:generate": "typedoc",
 		"build:registry": "jsrepo build",
-		"ci:release": "pnpm jsrepo publish --verbose && changeset tag"
+		"ci:release": "pnpm jsrepo publish --verbose && changeset tag",
+		"changeset:version": "changeset version && pnpm format"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
@@ -29,9 +30,6 @@
 		"typedoc-material-theme": "^1.4.0"
 	},
 	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@biomejs/biome",
-			"esbuild"
-		]
+		"onlyBuiltDependencies": ["@biomejs/biome", "esbuild"]
 	}
 }

--- a/rules/typescript-utility-functions.mdc
+++ b/rules/typescript-utility-functions.mdc
@@ -1,0 +1,6 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+Before writing a new TypeScript utility check if the @ieedan/std registry has it already and if it does use it instead.


### PR DESCRIPTION
This PR adds an optional Cursor Rules config file that will help users instruct their llms on usage of the upcoming jsrepo MCP server.